### PR TITLE
feat: 初步实现运行记录中心模块

### DIFF
--- a/src/run-center/index.ts
+++ b/src/run-center/index.ts
@@ -1,0 +1,25 @@
+export interface RunRecord {
+  id: string;
+  input: string;
+  output: string;
+  createdAt: number;
+}
+
+const runQueue: RunRecord[] = [];
+
+export function logRun(record: RunRecord): void {
+  runQueue.push(record);
+}
+
+export function getRunRecords(): RunRecord[] {
+  return [...runQueue];
+}
+
+export function clearRunRecords(): void {
+  runQueue.length = 0;
+}
+
+export function RunRecordList() {
+  // TODO: 实现记录列表组件
+  return getRunRecords();
+}

--- a/src/run-center/run-center.test.ts
+++ b/src/run-center/run-center.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { logRun, getRunRecords, clearRunRecords, type RunRecord } from './index';
+
+describe('run-center', () => {
+  beforeEach(() => {
+    clearRunRecords();
+  });
+
+  it('logs and retrieves records', () => {
+    const record: RunRecord = {
+      id: '1',
+      input: 'input data',
+      output: 'output data',
+      createdAt: Date.now(),
+    };
+
+    logRun(record);
+
+    const records = getRunRecords();
+    expect(records).toHaveLength(1);
+    expect(records[0]).toEqual(record);
+  });
+});


### PR DESCRIPTION
## Summary
- 定义 `RunRecord` 类型和内存队列
- 提供 `logRun`/`getRunRecords` 等接口
- 添加记录列表组件框架
- 编写基础测试覆盖记录插入与读取

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a72f7ff9f8832a8dda9a4e7b2154bd