### PR TITLE
docs: 添加项目 README 及模块设计文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Superflow
+
+Superflow 致力于构建一个由 AI 驱动的可编辑工作流平台，帮助用户从业务想法快速落地可运行的流程。
+
+## P0 功能清单
+- Ideas → 蓝图 → Flow 的基础闭环
+- NodePage：代码编辑、运行、日志与 AI 生成/修复
+- Web Components：输出 `<workflow-node>` 与 `<workflow-flow>` MVP
+- 本地持久化：使用 localStorage，支持导入/导出
+
+## 启动方式
+1. 安装依赖：`npm install`
+2. 运行测试：`npm test`
+   
+目前尚未提供独立运行脚本，可通过测试命令验证基础功能。
+
+## 开发约定
+项目遵循 [CLAUDE.md](./CLAUDE.md) 中的编码规范：使用 TypeScript、以 Prettier(2 空格缩进、分号、单引号) 格式化，采用 ES Module `import`/`export` 语法，并在提交前运行 `npm test`。

--- a/docs/file-directory.md
+++ b/docs/file-directory.md
@@ -1,29 +1,33 @@
-# Project File Directory
+# 项目文件结构
 
-This document outlines the initial directory structure derived from the v1 PR requirements.
+以下目录树展示代码与文档的对应关系。
 
 ```
 superflow/
+├── README.md
 ├── src/
 │   ├── ideas/
 │   ├── planner/
 │   ├── flow/
 │   ├── nodes/
 │   ├── run-center/
-│   └── shared/
+│   ├── shared/
+│   └── test/
 ├── public/
 └── docs/
-    ├── pr01.md
-    └── file-directory.md
+    ├── file-directory.md
+    ├── ideas.md
+    ├── planner.md
+    └── pr01.md
 ```
 
-## Directory Map
-
-- `src/ideas`: idea to blueprint processing
-- `src/planner`: converts blueprints to DAG flows
-- `src/flow`: flow canvas and runtime
-- `src/nodes`: individual code nodes and related logic
-- `src/run-center`: run center observability
-- `src/shared`: shared utilities and types
-- `public`: static assets
-- `docs`: documentation, including PRs and architecture notes
+## 目录说明
+- `src/ideas`：想法到蓝图的处理
+- `src/planner`：蓝图到流程 DAG 的转换
+- `src/flow`：流程画布与运行时
+- `src/nodes`：节点实现与相关逻辑
+- `src/run-center`：运行中心观测
+- `src/shared`：共享工具与类型
+- `src/test`：示例测试与测试配置
+- `public`：静态资源
+- `docs`：项目文档

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -1,0 +1,14 @@
+# Ideas 模块设计
+
+Ideas 模块负责将用户的自然语言需求解析为结构化的需求蓝图，为后续的流程规划提供输入。
+
+## 核心流程
+1. 接收文本形式的业务想法。
+2. 调用 LLM 生成包含节点概览与关系的蓝图 JSON。
+
+## 接口示例
+```ts
+export interface IdeaService {
+  parse(input: string): Promise<Blueprint>;
+}
+```

--- a/docs/planner.md
+++ b/docs/planner.md
@@ -1,0 +1,14 @@
+# Planner 模块设计
+
+Planner 模块将蓝图转换为可执行的流程 DAG，并输出节点列表与依赖关系。
+
+## 核心职责
+- 解析蓝图中的节点与边信息。
+- 生成带有输入输出定义的流程图结构。
+
+## 接口示例
+```ts
+export interface Planner {
+  plan(blueprint: Blueprint): Promise<Flow>;
+}
+```


### PR DESCRIPTION
## Summary
- 新增 README 概述目标、P0 功能及启动方式，并引用 CLAUDE.md 编码规范
- 添加 docs/ideas.md 与 docs/planner.md 记录各模块设计与接口
- 更新 docs/file-directory.md 反映新的文档与 src/test 目录

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a72f80c4d0832aa4bf5b40c360168f