### PR TITLE
feat: 添加流程存储工具及导入导出支持

### DIFF
--- a/src/flow/index.ts
+++ b/src/flow/index.ts
@@ -1,0 +1,18 @@
+import { loadFlow, saveFlow } from '../shared/storage';
+
+export interface FlowData {
+  [key: string]: unknown;
+}
+
+export class Flow {
+  data: FlowData;
+
+  constructor() {
+    this.data = loadFlow<FlowData>() ?? {};
+  }
+
+  update(data: FlowData): void {
+    this.data = data;
+    saveFlow(this.data);
+  }
+}

--- a/src/nodes/NodePage.ts
+++ b/src/nodes/NodePage.ts
@@ -1,0 +1,25 @@
+import { exportFlow, importFlow } from '../shared/storage';
+
+export function setupNodePage(
+  exportButton: HTMLButtonElement,
+  importInput: HTMLInputElement
+): void {
+  exportButton.addEventListener('click', () => {
+    const data = exportFlow();
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'flow.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  importInput.addEventListener('change', async () => {
+    const file = importInput.files?.[0];
+    if (file) {
+      const text = await file.text();
+      importFlow(text);
+    }
+  });
+}

--- a/src/shared/__tests__/storage.test.ts
+++ b/src/shared/__tests__/storage.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { saveFlow, loadFlow, exportFlow, importFlow } from '../storage';
+
+declare const global: { localStorage: Storage };
+
+describe('storage', () => {
+  let store: Record<string, string>;
+  let mockStorage: Storage;
+
+  beforeEach(() => {
+    store = {};
+    mockStorage = {
+      getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
+      setItem: vi.fn((key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete store[key];
+      }),
+      clear: vi.fn(() => {
+        store = {};
+      }),
+      key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+      get length() {
+        return Object.keys(store).length;
+      }
+    } as Storage;
+
+    vi.stubGlobal('localStorage', mockStorage);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('saves and loads flow', () => {
+    const data = { hello: 'world' };
+    saveFlow(data);
+    expect(mockStorage.setItem).toHaveBeenCalledWith('superflow:flow', JSON.stringify(data));
+    expect(loadFlow()).toEqual(data);
+  });
+
+  it('exports flow', () => {
+    saveFlow({ a: 1 });
+    const exported = exportFlow();
+    expect(exported).toBe(JSON.stringify({ a: 1 }, null, 2));
+  });
+
+  it('imports flow', () => {
+    const json = JSON.stringify({ b: 2 });
+    importFlow(json);
+    expect(loadFlow()).toEqual({ b: 2 });
+  });
+});

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -1,0 +1,23 @@
+const FLOW_KEY = 'superflow:flow';
+
+export function saveFlow(flow: unknown, storage: Storage = globalThis.localStorage): void {
+  storage.setItem(FLOW_KEY, JSON.stringify(flow));
+}
+
+export function loadFlow<T = unknown>(storage: Storage = globalThis.localStorage): T | null {
+  const raw = storage.getItem(FLOW_KEY);
+  return raw ? (JSON.parse(raw) as T) : null;
+}
+
+export function exportFlow(storage: Storage = globalThis.localStorage): string {
+  const flow = loadFlow(storage);
+  return JSON.stringify(flow ?? {}, null, 2);
+}
+
+export function importFlow(json: string, storage: Storage = globalThis.localStorage): unknown {
+  const flow = JSON.parse(json);
+  saveFlow(flow, storage);
+  return flow;
+}
+
+export default { saveFlow, loadFlow, exportFlow, importFlow };


### PR DESCRIPTION
## Summary
- 封装 saveFlow、loadFlow、exportFlow、importFlow
- Flow 更新时自动保存
- NodePage 增加手动导入导出逻辑
- 单元测试模拟 localStorage 验证持久化

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a72f7ef91c832a9799c09487123fae