### PR TITLE
实现蓝图生成与流程渲染的基础模块

### DIFF
--- a/src/flow/__tests__/renderFlow.test.ts
+++ b/src/flow/__tests__/renderFlow.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { renderFlow } from '../renderFlow';
+import { generateBlueprint } from '../../ideas/generateBlueprint';
+
+describe('renderFlow', () => {
+  it('返回包含节点和边的 ReactFlow 对象', () => {
+    const blueprint = generateBlueprint('');
+    const flow = renderFlow(blueprint);
+    expect(flow.type).toBe('ReactFlow');
+    expect(flow.nodes).toBeDefined();
+    expect(flow.edges).toBeDefined();
+  });
+});

--- a/src/flow/renderFlow.ts
+++ b/src/flow/renderFlow.ts
@@ -1,0 +1,22 @@
+import { blueprintToDag } from '../planner/blueprintToDag';
+
+interface ReactFlowObject {
+  type: 'ReactFlow';
+  nodes: unknown[];
+  edges: unknown[];
+}
+
+// 简化的 React Flow 组件占位实现
+function ReactFlow({ nodes, edges }: { nodes: unknown[]; edges: unknown[] }): ReactFlowObject {
+  return { type: 'ReactFlow', nodes, edges };
+}
+
+/**
+ * 使用 React Flow（占位实现）渲染蓝图。
+ */
+export function renderFlow(blueprint: Parameters<typeof blueprintToDag>[0]): ReactFlowObject {
+  const { nodes, edges } = blueprintToDag(blueprint);
+  return ReactFlow({ nodes, edges });
+}
+
+export default renderFlow;

--- a/src/ideas/__tests__/generateBlueprint.test.ts
+++ b/src/ideas/__tests__/generateBlueprint.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { generateBlueprint } from '../generateBlueprint';
+
+describe('generateBlueprint', () => {
+  it('返回包含步骤的蓝图', () => {
+    const blueprint = generateBlueprint('任意需求');
+    expect(blueprint.steps.length).toBeGreaterThan(0);
+    expect(blueprint.steps[0]).toHaveProperty('id');
+  });
+});

--- a/src/ideas/generateBlueprint.ts
+++ b/src/ideas/generateBlueprint.ts
@@ -1,0 +1,25 @@
+export interface BlueprintStep {
+  id: string;
+  label: string;
+  next: string[];
+}
+
+export interface Blueprint {
+  requirement: string;
+  steps: BlueprintStep[];
+}
+
+/**
+ * 根据文本需求生成蓝图。当前实现返回固定示例。
+ */
+export function generateBlueprint(requirement: string): Blueprint {
+  return {
+    requirement,
+    steps: [
+      { id: 'start', label: '开始', next: ['end'] },
+      { id: 'end', label: '结束', next: [] },
+    ],
+  };
+}
+
+export default generateBlueprint;

--- a/src/planner/__tests__/blueprintToDag.test.ts
+++ b/src/planner/__tests__/blueprintToDag.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { blueprintToDag } from '../blueprintToDag';
+import { generateBlueprint } from '../../ideas/generateBlueprint';
+
+describe('blueprintToDag', () => {
+  it('将蓝图转换为节点和边', () => {
+    const blueprint = generateBlueprint('');
+    const { nodes, edges } = blueprintToDag(blueprint);
+    expect(nodes).toHaveLength(2);
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toEqual({ id: 'start-end', source: 'start', target: 'end' });
+  });
+});

--- a/src/planner/blueprintToDag.ts
+++ b/src/planner/blueprintToDag.ts
@@ -1,0 +1,40 @@
+import type { Blueprint } from '../ideas/generateBlueprint';
+
+export interface DagNode {
+  id: string;
+  data: { label: string };
+  position: { x: number; y: number };
+}
+
+export interface DagEdge {
+  id: string;
+  source: string;
+  target: string;
+}
+
+export interface Dag {
+  nodes: DagNode[];
+  edges: DagEdge[];
+}
+
+/**
+ * 将蓝图转换为可用于渲染的 DAG 结构。
+ */
+export function blueprintToDag(blueprint: Blueprint): Dag {
+  const nodes: DagNode[] = blueprint.steps.map((step, index) => ({
+    id: step.id,
+    data: { label: step.label },
+    position: { x: 0, y: index * 100 },
+  }));
+
+  const edges: DagEdge[] = [];
+  for (const step of blueprint.steps) {
+    for (const target of step.next) {
+      edges.push({ id: `${step.id}-${target}`, source: step.id, target });
+    }
+  }
+
+  return { nodes, edges };
+}
+
+export default blueprintToDag;


### PR DESCRIPTION
## 总结
- 新增 `generateBlueprint`，根据文本需求生成示例蓝图。
- 实现 `blueprintToDag`，把蓝图步骤转换成节点和边。
- 添加 `renderFlow`，以简化的 React Flow 组件渲染 DAG。
- 为上述功能编写 Vitest 单元测试。

## 测试
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a72f7dc380832abcabd4129dcb2d94