### PR TITLE
feat: 新增 workflow 组件

### DIFF
--- a/docs/workflow-components.md
+++ b/docs/workflow-components.md
@@ -1,0 +1,38 @@
+# Workflow 组件
+
+提供两个自定义元素用于调试节点与展示流程。
+
+## `<workflow-node>`
+
+- 封装 `NodePage`，用于单节点调试。
+- 暴露方法：
+  - `run(input)`：运行节点，默认返回输入。
+  - `onLog(handler)`：监听日志输出。
+
+```html
+<workflow-node id="n1"></workflow-node>
+<script type="module">
+  import '../src/nodes/index.ts';
+  const el = document.getElementById('n1');
+  el.onLog((m) => console.log(m));
+  el.run({ msg: 'hi' });
+</script>
+```
+
+## `<workflow-flow>`
+
+- 加载有向无环图（DAG）并只读展示。
+- 可通过 `run(start, input)` 触发子图运行。
+
+```html
+<workflow-flow id="flow"></workflow-flow>
+<script type="module">
+  import '../src/flow/index.ts';
+  const flow = document.getElementById('flow');
+  flow.graph = {
+    nodes: { a: (x) => x + 1, b: (x) => x * 2 },
+    edges: [{ from: 'a', to: 'b' }],
+  };
+  console.log(flow.run('a', 1)); // 4
+</script>
+```

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Superflow Demo</title>
+    <script type="module">
+      import '../src/nodes/index.ts';
+      import '../src/flow/index.ts';
+
+      window.addEventListener('DOMContentLoaded', () => {
+        const node = document.querySelector('workflow-node') as any;
+        node.onLog((m: string) => console.log('log:', m));
+        node.run({ hello: 'world' });
+
+        const flow = document.querySelector('workflow-flow') as any;
+        flow.graph = {
+          nodes: {
+            a: (x: number) => x + 1,
+            b: (x: number) => x * 2,
+          },
+          edges: [{ from: 'a', to: 'b' }],
+        };
+        console.log('flow result', flow.run('a', 1));
+      });
+    </script>
+  </head>
+  <body>
+    <h1>Superflow 示例</h1>
+    <workflow-node></workflow-node>
+    <workflow-flow></workflow-flow>
+  </body>
+</html>

--- a/src/flow/flow.test.ts
+++ b/src/flow/flow.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import './index';
+
+describe('<workflow-flow>', () => {
+  it('should run subgraph sequentially', () => {
+    const el = document.createElement('workflow-flow') as any;
+    document.body.appendChild(el);
+    el.graph = {
+      nodes: {
+        a: (x: number) => x + 1,
+        b: (x: number) => x * 2,
+      },
+      edges: [{ from: 'a', to: 'b' }],
+    };
+    const result = el.run('a', 1);
+    expect(result).toBe(4);
+  });
+});

--- a/src/flow/flow.ts
+++ b/src/flow/flow.ts
@@ -1,0 +1,29 @@
+export interface DAG {
+  nodes: Record<string, (input: any) => any>;
+  edges: Array<{ from: string; to: string }>;
+}
+
+export class Flow {
+  private graph?: DAG;
+
+  constructor(private host: HTMLElement) {}
+
+  load(graph: DAG) {
+    this.graph = graph;
+    this.host.innerHTML = `<pre>${JSON.stringify(graph, null, 2)}</pre>`;
+  }
+
+  /** 从指定节点开始按连线运行子图 */
+  runSubgraph(start: string, input: any): any {
+    if (!this.graph) return undefined;
+    let current = start;
+    let value = this.graph.nodes[current](input);
+    while (true) {
+      const edge = this.graph.edges.find((e) => e.from === current);
+      if (!edge) break;
+      current = edge.to;
+      value = this.graph.nodes[current](value);
+    }
+    return value;
+  }
+}

--- a/src/flow/index.ts
+++ b/src/flow/index.ts
@@ -1,0 +1,33 @@
+import { Flow, DAG } from './flow';
+
+/** `<workflow-flow>` 元素，用于加载 DAG 并运行子图 */
+export class WorkflowFlowElement extends HTMLElement {
+  private runner?: Flow;
+  private _graph?: DAG;
+
+  connectedCallback() {
+    const root = this.attachShadow({ mode: 'open' });
+    const container = document.createElement('div');
+    root.appendChild(container);
+    this.runner = new Flow(container);
+    if (this._graph) this.runner.load(this._graph);
+  }
+
+  set graph(graph: DAG) {
+    this._graph = graph;
+    if (this.runner) this.runner.load(graph);
+  }
+
+  get graph() {
+    return this._graph;
+  }
+
+  /** 触发子图运行 */
+  run(start: string, input: any) {
+    return this.runner?.runSubgraph(start, input);
+  }
+}
+
+customElements.define('workflow-flow', WorkflowFlowElement);
+
+export { DAG };

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -1,0 +1,27 @@
+import { NodePage, LogHandler } from './node-page';
+
+/** `<workflow-node>` 自定义元素 */
+export class WorkflowNodeElement extends HTMLElement {
+  private page?: NodePage;
+
+  connectedCallback() {
+    const root = this.attachShadow({ mode: 'open' });
+    const container = document.createElement('div');
+    root.appendChild(container);
+    this.page = new NodePage(container);
+  }
+
+  /** 运行节点 */
+  run<T = unknown>(input: T): T | undefined {
+    return this.page?.run(input);
+  }
+
+  /** 注册日志回调 */
+  onLog(handler: LogHandler) {
+    this.page?.onLog(handler);
+  }
+}
+
+customElements.define('workflow-node', WorkflowNodeElement);
+
+export { NodePage };

--- a/src/nodes/node-page.ts
+++ b/src/nodes/node-page.ts
@@ -1,0 +1,28 @@
+export type LogHandler = (msg: string) => void;
+
+export class NodePage {
+  private logHandlers: LogHandler[] = [];
+  private logEl: HTMLElement;
+
+  constructor(private host: HTMLElement) {
+    this.logEl = document.createElement('pre');
+    this.logEl.id = 'log';
+    this.host.appendChild(this.logEl);
+  }
+
+  /** 运行节点，默认直接返回输入 */
+  run<T = unknown>(input: T): T {
+    this.emit(`run: ${JSON.stringify(input)}`);
+    return input;
+  }
+
+  /** 注册日志回调 */
+  onLog(handler: LogHandler) {
+    this.logHandlers.push(handler);
+  }
+
+  private emit(message: string) {
+    this.logHandlers.forEach((h) => h(message));
+    this.logEl.textContent += message + '\n';
+  }
+}

--- a/src/nodes/node.test.ts
+++ b/src/nodes/node.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import './index';
+
+describe('<workflow-node>', () => {
+  it('should run and emit logs', () => {
+    const el = document.createElement('workflow-node') as any;
+    document.body.appendChild(el);
+    const logs: string[] = [];
+    el.onLog((m: string) => logs.push(m));
+    const result = el.run({ foo: 'bar' });
+    expect(result).toEqual({ foo: 'bar' });
+    expect(logs.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- 新增 `<workflow-node>` 自定义元素，封装 NodePage 并提供 run/onLog 接口
- 新增 `<workflow-flow>` 元素，加载 DAG 并支持运行子图
- 补充示例页面、文档与基础测试

## Testing
- `npm test`
- `npm run lint` *(失败: Unexpected token 接口)*

------
https://chatgpt.com/codex/tasks/task_b_68a72f7dc4a4832a9b85f2610dc69441