### PR TITLE
feat: add node page and execution framework

### DIFF
--- a/src/nodes/NodePage.ts
+++ b/src/nodes/NodePage.ts
@@ -1,0 +1,51 @@
+import { executeNode } from './executeNode';
+import { applyPatch } from './applyPatch';
+
+/**
+ * NodePage component with code editor, input sample, run button and log panel.
+ */
+export class NodePage {
+  container: HTMLDivElement;
+  editor: HTMLTextAreaElement;
+  input: HTMLTextAreaElement;
+  runButton: HTMLButtonElement;
+  logPanel: HTMLPreElement;
+
+  constructor() {
+    this.container = document.createElement('div');
+
+    this.editor = document.createElement('textarea');
+    this.editor.placeholder = '在此编写 handler 函数';
+    this.container.appendChild(this.editor);
+
+    this.input = document.createElement('textarea');
+    this.input.placeholder = '输入 JSON 示例';
+    this.container.appendChild(this.input);
+
+    this.runButton = document.createElement('button');
+    this.runButton.textContent = '运行';
+    this.runButton.addEventListener('click', () => {
+      void this.run();
+    });
+    this.container.appendChild(this.runButton);
+
+    this.logPanel = document.createElement('pre');
+    this.container.appendChild(this.logPanel);
+  }
+
+  async run(): Promise<void> {
+    this.logPanel.textContent = '';
+    try {
+      const inputValue = this.input.value ? JSON.parse(this.input.value) : null;
+      const { output, logs } = await executeNode(this.editor.value, inputValue);
+      const allLogs = [...logs, `output: ${JSON.stringify(output)}`];
+      this.logPanel.textContent = allLogs.join('\n');
+    } catch (err) {
+      this.logPanel.textContent = String(err);
+    }
+  }
+
+  async applyPatch(diff: string): Promise<void> {
+    this.editor.value = await applyPatch(this.editor.value, diff);
+  }
+}

--- a/src/nodes/__tests__/NodePage.test.ts
+++ b/src/nodes/__tests__/NodePage.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { NodePage } from '../NodePage';
+
+describe('NodePage', () => {
+  it('渲染组件并能运行 handler', async () => {
+    const page = new NodePage();
+    document.body.appendChild(page.container);
+
+    page.editor.value = `async function handler(input){ console.log('hello', input); return input + 1; }`;
+    page.input.value = '1';
+
+    page.runButton.click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(page.logPanel.textContent).toContain('hello 1');
+    expect(page.logPanel.textContent).toContain('output: 2');
+  });
+});

--- a/src/nodes/__tests__/executeNode.test.ts
+++ b/src/nodes/__tests__/executeNode.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { executeNode } from '../executeNode';
+
+describe('executeNode', () => {
+  it('运行 handler 并返回输出和日志', async () => {
+    const code = `async function handler(input){ console.log('log', input); return input + 1; }`;
+    const result = await executeNode(code, 1);
+    expect(result.output).toBe(2);
+    expect(result.logs).toEqual(['log 1']);
+  });
+});

--- a/src/nodes/applyPatch.ts
+++ b/src/nodes/applyPatch.ts
@@ -1,0 +1,11 @@
+/**
+ * Apply a diff patch to existing code. Placeholder for AI-driven fixes.
+ * @param code original code string
+ * @param diff unified diff patch
+ * @returns patched code string
+ */
+export async function applyPatch(code: string, diff: string): Promise<string> {
+  console.warn('applyPatch is not implemented');
+  console.warn(diff);
+  return code;
+}

--- a/src/nodes/executeNode.ts
+++ b/src/nodes/executeNode.ts
@@ -1,0 +1,28 @@
+export interface ExecuteResult {
+  output: unknown;
+  logs: string[];
+}
+
+/**
+ * Execute a node handler and capture its output and logs.
+ * @param code handler code defining a `handler` function
+ * @param input input provided to handler
+ */
+export async function executeNode(
+  code: string,
+  input: unknown
+): Promise<ExecuteResult> {
+  const logs: string[] = [];
+  const fakeConsole = {
+    log: (...args: unknown[]) => {
+      logs.push(args.map((a) => String(a)).join(' '));
+    },
+  };
+  const runner = new Function(
+    'input',
+    'console',
+    `"use strict";${code}; return handler(input);`
+  );
+  const output = await runner(input, fakeConsole);
+  return { output, logs };
+}


### PR DESCRIPTION
## Summary
- add NodePage component with code editor, sample input, run button and log panel
- implement executeNode to run handlers and capture logs
- stub applyPatch interface for AI diff patches
- add unit tests for executeNode and NodePage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a72f7da8cc832aa3f10870882149a4