### PR TITLE
feat: 初始化各模块入口与构建配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "test": "echo 'No tests yet'"
+    "test": "echo 'No tests yet'",
+    "build": "tsc"
   },
   "devDependencies": {
     "prettier": "^3.2.5",

--- a/src/flow/index.ts
+++ b/src/flow/index.ts
@@ -1,0 +1,1 @@
+export interface Flow {}

--- a/src/ideas/index.ts
+++ b/src/ideas/index.ts
@@ -1,0 +1,1 @@
+export interface Idea {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+export function hello(): string {
+  return 'hello';
+}

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -1,0 +1,1 @@
+export interface Node {}

--- a/src/planner/index.ts
+++ b/src/planner/index.ts
@@ -1,0 +1,1 @@
+export interface Planner {}

--- a/src/run-center/index.ts
+++ b/src/run-center/index.ts
@@ -1,0 +1,1 @@
+export class RunCenter {}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,0 +1,1 @@
+export interface Shared {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- 新增 `src/index.ts`，导出占位函数 `hello`
- 为 `ideas`、`planner` 等目录补充 `index.ts`
- 添加 `tsconfig.json` 与 `build` 脚本支持编译

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a71aca269c832aa672419ef7d796dc