### PR TITLE
test: 配置 Jest 并添加示例测试

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "test": "echo 'No tests yet'"
+    "test": "jest"
   },
   "devDependencies": {
     "prettier": "^3.2.5",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.5"
   }
 }

--- a/src/ideas/__tests__/sample.test.ts
+++ b/src/ideas/__tests__/sample.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from '@jest/globals';
+
+describe('sample', () => {
+  it('adds 1 + 1 to equal 2', () => {
+    expect(1 + 1).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- 配置 `ts-jest` 以在 Jest 中处理 TypeScript
- 将测试脚本改为 `jest` 并添加相关依赖
- 在 `src/ideas` 下加入首个示例测试

## Testing
- `npm test` *(失败：jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a71c570abc832a9962cfbbf389660c