### PR TITLE
fix: 精简 ESLint 推荐配置

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,11 +1,7 @@
 module.exports = {
   root: true,
   env: { browser: true, es2020: true },
-  extends: [
-    'eslint:recommended',
-    '@typescript-eslint/recommended',
-    'eslint:recommended',
-  ],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',
   plugins: ['react-refresh'],
@@ -15,4 +11,4 @@ module.exports = {
       { allowConstantExport: true },
     ],
   },
-}
+};

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,7 +1,7 @@
-import { expect, afterEach } from 'vitest'
-import { cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
 
 // runs a cleanup after each test case (e.g. clearing jsdom)
 afterEach(() => {
-  cleanup()
-})
+  cleanup();
+});


### PR DESCRIPTION
## Summary
- 移除重复的 `eslint:recommended` 并改用 `plugin:@typescript-eslint/recommended`
- 删除测试设置文件中未使用的 `expect` 导入

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to resolve import "@testing-library/react" from "src/test/setup.ts"; tried to install `@testing-library/react` but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a72114625c832aa9c85296ea244c0a