### PR TITLE
chore: 添加husky与lint-staged支持

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+# husky

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+npx lint-staged
+
+npm test
+prettier --check .

--- a/package.json
+++ b/package.json
@@ -3,10 +3,16 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "test": "echo 'No tests yet'"
+    "test": "echo 'No tests yet'",
+    "prepare": "husky install"
   },
   "devDependencies": {
     "prettier": "^3.2.5",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "husky": "^9.0.11",
+    "lint-staged": "^15.2.2"
+  },
+  "lint-staged": {
+    "*": "prettier --write --ignore-unknown"
   }
 }


### PR DESCRIPTION
## Summary
- 安装 husky 与 lint-staged
- 增加 pre-commit 钩子执行 lint-staged、npm test 及 prettier --check
- 在 package.json 中加入 lint-staged 配置

## Testing
- `npm test`
- `npx prettier package.json --check`

------
https://chatgpt.com/codex/tasks/task_b_68a71c592dd4832a8578700903aa6ece